### PR TITLE
feat: Create OCI image from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Build stage: use Alpine with build tools
+FROM alpine:3.22 AS builder
+
+WORKDIR /usr/src
+
+RUN apk add --no-cache gcc musl-dev make
+
+COPY ./src .
+
+RUN make release
+
+# Assemble runtime image
+FROM alpine:3.22
+
+COPY --from=builder /usr/src/mpdirectory .
+
+RUN adduser -D -g "mpdirectory user" mpdirectory
+
+USER mpdirectory
+
+ENTRYPOINT ["/mpdirectory"]
+
+CMD ["-h"]
+
+EXPOSE 27950/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: use Alpine with build tools
-FROM alpine:3.22 AS builder
+FROM alpine:3.22.1 AS builder
 
 WORKDIR /usr/src
 
@@ -10,7 +10,7 @@ COPY ./src .
 RUN make release
 
 # Assemble runtime image
-FROM alpine:3.22
+FROM alpine:3.22.1
 
 COPY --from=builder /usr/src/mpdirectory .
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ to compile the debug version
 The resulting binary is just called `mpdirectory`
 
 ## Docker
+
+Build OCI
+```bash
+docker build -t mpdirectory .
 ```
-git clone https://github.com/nuclearmonster/mpdirectory_docker
-cd mpdirectory
-docker compose up -d
+
+Running as a container
+
+```bash
+docker run --rm -p 27950:27950/udp mpdirectory -f
 ```


### PR DESCRIPTION
Add a multi-stage Dockerfile builing mp-directory from source. Make the Docker build a first-class citizen of the repository and don't depend on a 3rd party repo.

Added instructions to build and run the container image.